### PR TITLE
Add tricky generic handler test

### DIFF
--- a/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
+++ b/test/MediatR.Tests/MicrosoftExtensionsDI/Handlers.cs
@@ -57,6 +57,16 @@ namespace MediatR.Extensions.Microsoft.DependencyInjection.Tests
         }
     }
 
+    public class GenericNotification<T> : INotification
+    {
+
+    }
+
+    public class GenericHandler<T> : INotificationHandler<GenericNotification<T>>
+    {
+        public Task Handle(GenericNotification<T> notification, CancellationToken cancellationToken) => Task.CompletedTask;
+    }
+
     public class DingAsyncHandler : IRequestHandler<Ding>
     {
         public Task Handle(Ding message, CancellationToken cancellationToken) => Task.CompletedTask;


### PR DESCRIPTION
Sorry for the "307 additions and 297 deletions", github decided to "fix line endings" to windows-style.

Basically what I added is this tricky test case:

```csharp
public class GenericNotification<T> : INotification
{

}

public class GenericHandler<T> : INotificationHandler<GenericNotification<T>>
{
    public Task Handle(GenericNotification<T> notification, CancellationToken cancellationToken) => Task.CompletedTask;
}
```

It ruines some of the tests in your new method of open generics registration, so it should be really helpful to you, in my humble opinion.

As I see it, it should either NOT be registered (since it can't guarantee something, like every possible type or whatever), or it should be registered without any errors.